### PR TITLE
xargo is only installed once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
-cache: cargo
+]cache: cargo
 dist: trusty
 
 git:
   depth: 1
 
-install:
-- cargo install xargo --force
-- rustup component add rust-src
+install: scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
 language: rust
 rust: nightly
 script: sh scripts/x86_64-unknown-linux-cirs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 git:
   depth: 1
 
-install: scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
+install: sh scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
 language: rust
 rust: nightly
 script: sh scripts/x86_64-unknown-linux-cirs.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-]cache: cargo
+cache: cargo
 dist: trusty
 
 git:

--- a/scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
+++ b/scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -ex
+
+if [[ ! -e ~/.cargo/bin/xargo  ]]
+then
+	cargo install xargo
+fi
+
+xargo -vV
+
+rustup component add rust-src

--- a/scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
+++ b/scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
@@ -7,6 +7,6 @@ then
 	cargo install xargo
 fi
 
+rustup component add rust-src
 xargo -vV
 
-rustup component add rust-src


### PR DESCRIPTION
# Summary

Does not try to reinstall xargo if xargo is already installed. This is better than the current system in which we force to install xargo even if it is installed.

# Related Issues and PRs

Fixes #2 
  