### PR TITLE
Disable email notifications on success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ git:
 
 install: sh scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
 language: rust
+
+notifications:
+    email: 
+        on_success: never
+
 rust: nightly
 script: sh scripts/x86_64-unknown-linux-cirs.sh
 sudo: required


### PR DESCRIPTION
# Summary

Travis only sends emails on build failures now

# Related Issues and PRs

#7
