### PR TITLE
Dont build if the branch ends in a '.tmp'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
+branches:
+    except:
+    - /.*(.tmp)$
+
 cache: cargo
 dist: trusty
 
 git:
-  depth: 1
+    depth: 1
 
 install: sh scripts/ci/travis/install/x86_64-unknown-linux-cirs.sh
 language: rust


### PR DESCRIPTION
# Summary

This is unnecessary build attempts as the branches are deleted almost instantly, creating failed build junk in the commit history

# Related Issues and PRs

closes #12 